### PR TITLE
clean up timestamps return

### DIFF
--- a/src/pynwb/io/base.py
+++ b/src/pynwb/io/base.py
@@ -59,9 +59,15 @@ class TimeSeriesMap(NWBContainerMapper):
         if tstamps_builder is None:
             return None
         if isinstance(tstamps_builder, LinkBuilder):
-            if tstamps_builder.builder.parent is None:
-                return
-            target = tstamps_builder.builder
-            return manager.construct(target.parent)
+            # if the parent of our target is available, return the parent object
+            # Otherwise, return the dataset in the target builder
+            #
+            # NOTE: it is not available when data is externally linked
+            # and we haven't explicitly read that file
+            if tstamps_builder.builder.parent is not None:
+                target = tstamps_builder.builder
+                return manager.construct(target.parent)
+            else:
+                return tstamps_builder.builder.data
         else:
             return tstamps_builder.data


### PR DESCRIPTION
## Motivation

Make the return of linked timestamps datasets more explicit.

## How to test the behavior?
Run the test provided by @NileGraddis 

## Checklist

- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR description clearly describes problem and the solution?
- [X] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
